### PR TITLE
Upgrade openssl to fix CVE-2022-2097

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ ENV JAVA_FLAGS="-XX:+UseStringDeduplication -XX:+UseG1GC -XX:G1HeapRegionSize=4M
 
 WORKDIR /data
 
-RUN addgroup -S velocity && \
+RUN apk add --upgrade --no-cache openssl && \
+    addgroup -S velocity && \
     adduser -S velocity -G velocity && \
     chown velocity:velocity /data
 


### PR DESCRIPTION
We upgrade openssl using `apk add --upgrade --no-cache openssl` in `Dockerfile` to fix [CVE-2022-2097](https://avd.aquasec.com/nvd/2022/cve-2022-2097/).